### PR TITLE
Apply dual-sided fade effect to event timeline

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -199,3 +199,61 @@ html, body {
 /* Hide scrollbar but keep scroll functionality */
 .scrollbar-hide::-webkit-scrollbar { display: none; }
 .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
+
+/* Timeline fade effects */
+.timeline-fade-effect {
+  position: relative;
+}
+
+.timeline-fade-effect::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 15%;
+  height: 100%;
+  background: linear-gradient(to right, 
+    rgba(0, 0, 0, 0.15), 
+    rgba(0, 0, 0, 0.08), 
+    transparent
+  );
+  pointer-events: none;
+  z-index: 10;
+}
+
+.timeline-fade-effect::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 30%;
+  right: 0;
+  height: 100%;
+  background: linear-gradient(to right, 
+    transparent 0%, 
+    rgba(255, 255, 255, 0.1) 30%, 
+    rgba(255, 255, 255, 0.4) 60%, 
+    rgba(255, 255, 255, 0.8) 85%, 
+    rgba(255, 255, 255, 1) 100%
+  );
+  pointer-events: none;
+  z-index: 10;
+}
+
+/* Dark mode adjustments for timeline fade */
+.dark .timeline-fade-effect::before {
+  background: linear-gradient(to right, 
+    rgba(15, 15, 15, 0.15), 
+    rgba(15, 15, 15, 0.08), 
+    transparent
+  );
+}
+
+.dark .timeline-fade-effect::after {
+  background: linear-gradient(to right, 
+    transparent 0%, 
+    rgba(15, 15, 15, 0.1) 30%, 
+    rgba(15, 15, 15, 0.4) 60%, 
+    rgba(15, 15, 15, 0.8) 85%, 
+    rgba(15, 15, 15, 1) 100%
+  );
+}

--- a/src/components/ui/LiveEventsTicker.tsx
+++ b/src/components/ui/LiveEventsTicker.tsx
@@ -599,7 +599,7 @@ export function LiveEventsTicker({
         {/* Scrollable timeline */}
         <div
           ref={rowRef}
-          className="relative flex gap-4 py-4 px-8 bg-white dark:bg-[#0f0f0f] shadow-2xl rounded-t-3xl overflow-x-auto scrollbar-hide scroll-snap-x mandatory pointer-events-auto border-t border-gray-200/50 dark:border-gray-800/50"
+          className="timeline-fade-effect relative flex gap-4 py-4 px-8 bg-white dark:bg-[#0f0f0f] shadow-2xl rounded-t-3xl overflow-x-auto scrollbar-hide scroll-snap-x mandatory pointer-events-auto border-t border-gray-200/50 dark:border-gray-800/50"
         >
           {/* Timeline connector line - centered */}
           <div className="absolute top-1/2 left-8 right-8 h-0.5 bg-gradient-to-r from-transparent via-gray-300 dark:via-gray-600 to-transparent pointer-events-none transform -translate-y-1/2" />


### PR DESCRIPTION
Add CSS gradient overlays to the event timeline to create a left-to-right fade effect and a subtle left-side polish.